### PR TITLE
Add internal tooling to manage and update multiple repositories

### DIFF
--- a/packages/repo-management/.gitignore
+++ b/packages/repo-management/.gitignore
@@ -1,0 +1,2 @@
+/**/node_modules/*
+package-lock.json

--- a/packages/repo-management/.npmrc
+++ b/packages/repo-management/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/packages/repo-management/CHANGELOG.md
+++ b/packages/repo-management/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - 2020-07-29
+
+### New Features
+
+* Initial release.
+
+[Unreleased]: https://github.com/wearerequired/js/releases/tag/@wearerequired/wordpress-plugin-boilerplate@0.1.0...HEAD
+[0.1.0]: https://github.com/wearerequired/js/releases/tag/@wearerequired/wordpress-plugin-boilerplate@0.1.0

--- a/packages/repo-management/README.md
+++ b/packages/repo-management/README.md
@@ -1,0 +1,11 @@
+# @wearerequired/repo-management
+
+Internal tooling to manage and update multiple repositories at the same time.
+
+## Usage
+
+```bash
+npm link
+repo-management update-file # update and commit a file
+repo-management merge-pr # merge a pr by running composer install first
+```

--- a/packages/repo-management/bin/repo-management.js
+++ b/packages/repo-management/bin/repo-management.js
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+'use strict';
+require( '../lib/cli' ).parse( process.argv );

--- a/packages/repo-management/lib/cli.js
+++ b/packages/repo-management/lib/cli.js
@@ -1,0 +1,12 @@
+'use strict';
+
+const program = require( 'commander' );
+const updateFile = require( './commands/update-file' );
+const mergePR = require( './commands/merge-pr' );
+
+program.version( require( '../package.json' ).version );
+
+program.command( 'update-file' ).description( 'update and commit file' ).action( updateFile );
+program.command( 'merge-pr' ).description( 'merge a pr' ).action( mergePR );
+
+module.exports = program;

--- a/packages/repo-management/lib/commands/merge-pr.js
+++ b/packages/repo-management/lib/commands/merge-pr.js
@@ -1,0 +1,156 @@
+'use strict';
+
+const { promisify } = require( 'util' );
+const { tmpdir } = require( 'os' );
+const { join } = require( 'path' );
+const { Octokit } = require( '@octokit/rest' );
+const inquirer = require( 'inquirer' );
+const keytar = require( 'keytar' );
+const { log, format } = require( '../logger' );
+const Conf = require( 'conf' );
+const { mkdtemp } = require( 'fs' ).promises;
+const rimraf = promisify( require( 'rimraf' ) );
+const { run, sleep } = require( '../utils' );
+const { validateNotEmpty } = require( '../validation' );
+
+const config = new Conf();
+const OWNER = 'wearerequired';
+
+async function updateFile() {
+	// Get token from the keychain.
+	const storedGithubToken = await keytar.getPassword( 'repo-management', 'github' );
+	const lastInput = config.get( 'mergePRLastInput' );
+
+	const { githubToken, query } = await inquirer.prompt( [
+		{
+			type: 'password',
+			mask: '*',
+			name: 'githubToken',
+			default: storedGithubToken || undefined,
+			message: 'GitHub API token:',
+			validate: validateNotEmpty,
+		},
+		{
+			type: 'input',
+			name: 'query',
+			message: 'Search query:',
+			default: lastInput?.query || `user:${ OWNER }`,
+			validate: validateNotEmpty,
+		},
+	] );
+
+	// Add token to the keychain.
+	if ( storedGithubToken !== githubToken ) {
+		await keytar.setPassword( 'repo-management', 'github', githubToken );
+	}
+
+	config.set( 'mergePRLastInput', {
+		query,
+	} );
+
+	const octokit = new Octokit( {
+		auth: githubToken,
+		previews: [ 'mercy-preview' ],
+	} );
+
+	let searchResults;
+	try {
+		const { data } = await octokit.search.issuesAndPullRequests( {
+			q: `is:pr ${ query }`,
+		} );
+		searchResults = data;
+	} catch ( e ) {
+		log( format.error( 'PR search failed: ' + e.message ) );
+		return;
+	}
+
+	if ( ! searchResults?.items?.length ) {
+		log( format.warning( 'No pull requests found.' ) );
+		return;
+	}
+
+	const pullRequests = searchResults.items.map( ( pullRequest ) => {
+		const repoName = pullRequest.repository_url.replace( 'https://api.github.com/repos/', '' );
+		return {
+			name: `${ repoName }#${ pullRequest.number } ${ pullRequest.title }`,
+			value: `${ repoName }|${ pullRequest.number }`,
+		};
+	} );
+
+	const { selectedPullRequests } = await inquirer.prompt( [
+		{
+			type: 'checkbox',
+			name: 'selectedPullRequests',
+			choices: pullRequests,
+			message: 'Select pull requests',
+			pageSize: 15,
+		},
+	] );
+	if ( ! selectedPullRequests?.length ) {
+		log( format.error( '\n\nAborting.' ) );
+		process.exit();
+	}
+
+	log( `\nUpdating the following ${ selectedPullRequests.length } pull requests:` );
+	log( selectedPullRequests.join( ', ' ) );
+	log();
+
+	const { isReady } = await inquirer.prompt( [
+		{
+			type: 'expand',
+			name: 'isReady',
+			default: 2, // default to help in order to avoid clicking straight through
+			choices: [
+				{ key: 'y', name: 'Yes', value: true },
+				{ key: 'n', name: 'No', value: false },
+			],
+			message: 'Are you ready to proceed?',
+		},
+	] );
+
+	if ( ! isReady ) {
+		log( format.error( '\nAborted.' ) );
+		process.exit();
+	}
+
+	selectedPullRequests.forEach( async ( pullRequestData ) => {
+		const [ repoName, number ] = pullRequestData.split( '|' );
+
+		const checkoutDir = await mkdtemp( join( tmpdir(), 'merge-pr-' ) );
+		try {
+			await run( `gh repo clone ${ repoName } . -- --single-branch --branch master`, {
+				cwd: checkoutDir,
+			} );
+			await run( `gh pr checkout ${ number }`, { cwd: checkoutDir } );
+			await run( `composer install --no-progress --prefer-dist --no-ansi --no-interaction`, {
+				cwd: checkoutDir,
+			} );
+			const gitStatus = await run( `git status --porcelain`, {
+				cwd: checkoutDir,
+			} );
+			const changedFiles = gitStatus.trim().split( '\n' ).filter( Boolean );
+			if ( changedFiles.length > 0 ) {
+				await run( `git commit -am "Add modified files"`, {
+					cwd: checkoutDir,
+				} );
+				await run( `git push`, {
+					cwd: checkoutDir,
+				} );
+				await sleep( 5000 );
+				await run( `gh pr merge ${ number } --squash --delete-branch`, {
+					cwd: checkoutDir,
+				} );
+			} else {
+				await run( `gh pr merge ${ number } --squash --delete-branch`, {
+					cwd: checkoutDir,
+				} );
+			}
+		} catch ( err ) {
+			console.error( err ); // eslint-disable-line no-console
+		} finally {
+			await rimraf( checkoutDir );
+		}
+	} );
+}
+
+module.exports = updateFile;

--- a/packages/repo-management/lib/commands/update-file.js
+++ b/packages/repo-management/lib/commands/update-file.js
@@ -1,0 +1,191 @@
+'use strict';
+
+const { Octokit } = require( '@octokit/rest' );
+const inquirer = require( 'inquirer' );
+const keytar = require( 'keytar' );
+const fs = require( 'fs' ).promises;
+const untildify = require( 'untildify' );
+const { log, format } = require( '../logger' );
+const Conf = require( 'conf' );
+const { validateNotEmpty, validateFile } = require( '../validation' );
+
+const config = new Conf();
+const OWNER = 'wearerequired';
+
+async function updateFile() {
+	// Get token from the keychain.
+	const storedGithubToken = await keytar.getPassword( 'repo-management', 'github' );
+	const lastInput = config.get( 'lastInput' );
+
+	const { githubToken, path, branch, commitMessage, file, query } = await inquirer.prompt( [
+		{
+			type: 'password',
+			mask: '*',
+			name: 'githubToken',
+			default: storedGithubToken || undefined,
+			message: 'GitHub API token:',
+			validate: validateNotEmpty,
+		},
+		{
+			type: 'input',
+			name: 'path',
+			message: 'Path:',
+			default: lastInput?.path || undefined,
+			validate: validateNotEmpty,
+		},
+		{
+			type: 'input',
+			name: 'branch',
+			message: 'Branch:',
+			default: lastInput?.branch || 'master',
+			validate: validateNotEmpty,
+		},
+		{
+			type: 'input',
+			name: 'query',
+			message: 'Search query:',
+			default: lastInput?.query || `user:${ OWNER }`,
+			validate: validateNotEmpty,
+		},
+		{
+			type: 'input',
+			name: 'commitMessage',
+			message: 'Commit Message:',
+			default: ( answers ) => `Update ${ answers.path }.`,
+			validate: validateNotEmpty,
+		},
+		{
+			type: 'input',
+			name: 'file',
+			message: 'File:',
+			default: lastInput?.file || undefined,
+			validate: validateFile,
+			filter: async ( input ) => {
+				return await untildify( input );
+			},
+		},
+	] );
+
+	// Add token to the keychain.
+	if ( storedGithubToken !== githubToken ) {
+		await keytar.setPassword( 'repo-management', 'github', githubToken );
+	}
+
+	config.set( 'lastInput', {
+		path,
+		branch,
+		file,
+		query,
+	} );
+
+	const octokit = new Octokit( {
+		auth: githubToken,
+		previews: [ 'mercy-preview' ],
+	} );
+
+	let searchResults;
+	try {
+		const { data } = await octokit.search.repos( {
+			q: query,
+		} );
+		searchResults = data;
+	} catch ( e ) {
+		log( format.error( 'Repo search failed: ' + e.message ) );
+		return;
+	}
+
+	if ( ! searchResults?.items?.length ) {
+		log( format.warning( 'No repositories found.' ) );
+		return;
+	}
+
+	const repositories = searchResults.items.map( ( repo ) => {
+		return {
+			name: repo.name,
+			value: repo.name,
+		};
+	} );
+
+	repositories.sort( ( a, b ) => a.name.localeCompare( b.name ) );
+
+	const { selectedRepositories } = await inquirer.prompt( [
+		{
+			type: 'checkbox',
+			name: 'selectedRepositories',
+			choices: repositories,
+			message: 'Select repositories',
+			pageSize: 15,
+		},
+	] );
+	if ( ! selectedRepositories?.length ) {
+		log( format.error( '\n\nAborting.' ) );
+		process.exit();
+	}
+
+	log(
+		`\nUpdating '${ path }' for the following ${ selectedRepositories.length } repositories:`
+	);
+	log( selectedRepositories.join( ', ' ) );
+	log();
+
+	const { isReady } = await inquirer.prompt( [
+		{
+			type: 'expand',
+			name: 'isReady',
+			default: 2, // default to help in order to avoid clicking straight through
+			choices: [
+				{ key: 'y', name: 'Yes', value: true },
+				{ key: 'n', name: 'No', value: false },
+			],
+			message: 'Are you ready to proceed?',
+		},
+	] );
+
+	if ( ! isReady ) {
+		log( format.error( '\nAborted.' ) );
+		process.exit();
+	}
+
+	const content = await fs.readFile( file, { encoding: 'base64' } );
+
+	await selectedRepositories.forEach( async ( repo ) => {
+		// Check if file exists and get SHA/content.
+		let githubFileSha = null;
+		let githubFileContent = null;
+		try {
+			const { data: githubFile } = await octokit.repos.getContent( {
+				owner: OWNER,
+				repo,
+				path,
+				ref: branch,
+			} );
+
+			githubFileSha = githubFile.sha;
+			githubFileContent = githubFile.content.replace( /\n/g, '' );
+		} catch {}
+
+		// Check if content is unchanged.
+		if ( githubFileContent === content ) {
+			log( format.warning( `[${ repo }] Content is unchanged.` ) );
+			return;
+		}
+
+		// Update file with commit.
+		try {
+			const { data: updatedFile } = await octokit.repos.createOrUpdateFileContents( {
+				owner: OWNER,
+				repo,
+				path,
+				message: commitMessage,
+				content,
+				branch,
+				sha: githubFileSha,
+			} );
+			log( format.success( `[${ repo }] File updated. ${ updatedFile.commit.html_url }` ) );
+		} catch ( e ) {
+			log( format.error( `[${ repo }] File not updated: ${ e.message }` ) );
+		}
+	} );
+}
+
+module.exports = updateFile;

--- a/packages/repo-management/lib/logger.js
+++ b/packages/repo-management/lib/logger.js
@@ -1,0 +1,16 @@
+'use strict';
+
+const { red, yellow, green, bold } = require( 'colorette' );
+
+const log = console.log; // eslint-disable-line no-console
+const format = {
+	title: ( message ) => bold( message ),
+	error: ( message ) => bold( red( message ) ),
+	warning: ( message ) => yellow( message ),
+	success: ( message ) => bold( green( message ) ),
+};
+
+module.exports = {
+	log,
+	format,
+};

--- a/packages/repo-management/lib/utils.js
+++ b/packages/repo-management/lib/utils.js
@@ -1,0 +1,22 @@
+const ora = require( 'ora' );
+const { promisify } = require( 'util' );
+const exec = promisify( require( 'child_process' ).exec );
+
+async function run( command, options ) {
+	const spinner = ora( command ).start();
+	try {
+		const { stdout } = await exec( command, options );
+		spinner.succeed();
+		return stdout;
+	} catch ( err ) {
+		spinner.fail();
+		throw err;
+	}
+}
+
+const sleep = ( time ) => new Promise( ( resolve ) => setTimeout( resolve, time ) );
+
+module.exports = {
+	run,
+	sleep,
+};

--- a/packages/repo-management/lib/validation.js
+++ b/packages/repo-management/lib/validation.js
@@ -1,0 +1,20 @@
+const fs = require( 'fs' ).promises;
+
+const validateFile = async ( input ) => {
+	try {
+		const stats = await fs.stat( input );
+		if ( ! stats.isFile() ) {
+			return 'Path is not a file.';
+		}
+		return true;
+	} catch {
+		return 'File does not exist.';
+	}
+};
+
+const validateNotEmpty = async ( input ) => input && input.length > 0;
+
+module.exports = {
+	validateFile,
+	validateNotEmpty,
+};

--- a/packages/repo-management/package.json
+++ b/packages/repo-management/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@wearerequired/repo-management",
+  "version": "0.1.0",
+  "description": "Manage GitHub repos.",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/wearerequired/js.git"
+  },
+  "keywords": [
+    "cli",
+    "github",
+    "repository",
+    "management"
+  ],
+  "author": {
+    "name": "required gmbh",
+    "email": "info@required.com",
+    "url": "https://required.com"
+  },
+  "license": "MIT",
+  "private": true,
+  "bugs": {
+    "url": "https://github.com/wearerequired/js/issues"
+  },
+  "homepage": "https://github.com/wearerequired/js/tree/master/packages/repo-management#readme",
+  "dependencies": {
+    "@octokit/rest": "^18.0.6",
+    "colorette": "^1.2.1",
+    "commander": "^6.1.0",
+    "conf": "^7.1.2",
+    "inquirer": "^7.3.3",
+    "keytar": "^7.0.0",
+    "ora": "^5.1.0",
+    "rimraf": "^3.0.2",
+    "simple-git": "^2.21.0",
+    "untildify": "^4.0.0"
+  },
+  "engines": {
+    "node": ">=10.0"
+  },
+  "bin": "./bin/repo-management.js"
+}


### PR DESCRIPTION
Example:

```
❯ repo-management merge-pr
? GitHub API token: ****************************************
? Search query: user:wearerequired draft:false composer-deployer is:open
? Select pull requests wearerequired/foo-bar#72 Bump wearerequired/composer-deployer from 0.3.1 to 0.3.2

Updating the following 1 pull requests:
wearerequired/foo-bar|72

? Are you ready to proceed? Yes
✔ gh repo clone wearerequired/foo-bar . -- --single-branch --branch master
✔ gh pr checkout 72
✔ composer install --no-progress --prefer-dist --no-ansi --no-interaction
✔ git status --porcelain
✔ gh pr merge 72 --squash --delete-branch
```


```
❯ repo-management update-file
? GitHub API token: ****************************************
? Path: .github/workflows/deploy.yml
? Branch: master
? Search query: user:wearerequired topic:wordpress-site topic:deployer archived:false
? Commit Message: Update .github/workflows/deploy.yml.
? File: /Users/Dominik/Development/wearerequired/git/.github/workflow-templates/deploy.yml
? Select repositories (Press <space> to select, <a> to toggle all, <i> to invert selection)
❯◯ project-1
 ◯ project-2
 ◯ project-3
 ◯ project-4
 ◉ project-5
 ◯ project-6
 ◯ project-7
(Move up and down to reveal more choices)
```