### PR TITLE
Include the current branch ref when triggering a deployment

### DIFF
--- a/packages/setup-remote-server/lib/commands/server.js
+++ b/packages/setup-remote-server/lib/commands/server.js
@@ -511,10 +511,12 @@ Satisfy Any
 		`${ deployYMLData[ '.base' ].application } ${ environment } is now installed under ${ remotePath }`
 	);
 
+	log( 'Next Step: Deployment' );
+
 	await recursiveConfirm( {
 		type: 'confirm',
 		name: 'repoActions',
-		message: 'Are Actions enabled & secrets set on the repository?',
+		message: 'Are GitHub Actions enabled & secrets set on the repository?',
 		default: false,
 	} );
 
@@ -532,7 +534,7 @@ Satisfy Any
 
 	await runStep(
 		'Trigger deployment',
-		`Automatic deployment failed. Try running: gh workflow run deploy.yml --ref ${ currentBranch }`,
+		`Deployment failed. Try running: gh workflow run deploy.yml --ref ${ currentBranch }`,
 		async () => {
 			await exec( `gh workflow run deploy.yml --ref ${ currentBranch }`, {
 				WORKING_DIR,

--- a/packages/setup-remote-server/lib/commands/server.js
+++ b/packages/setup-remote-server/lib/commands/server.js
@@ -507,11 +507,22 @@ Satisfy Any
 		} );
 	}
 
+	let currentBranch;
+	await runStep( 'Fetch current branch', 'Failed to fetch current branch', async () => {
+		currentBranch = await exec( 'git branch --show-current', {
+			WORKING_DIR,
+			env: {
+				PATH: process.env.PATH,
+				HOME: process.env.HOME,
+			},
+		} );
+	} );
+
 	await runStep(
 		'Trigger deployment',
-		'Automatic deployment failed. Try running: gh workflow run deploy.yml',
+		`Automatic deployment failed. Try running: gh workflow run deploy.yml --ref ${ currentBranch }`,
 		async () => {
-			await exec( 'gh workflow run deploy.yml', {
+			await exec( `gh workflow run deploy.yml --ref ${ currentBranch }`, {
 				WORKING_DIR,
 				env: {
 					PATH: process.env.PATH,


### PR DESCRIPTION
Otherwise by default master is used

~Needs to be tested.~ Tested with Corina for Boris' production setup

To test run `npm link` in `packages/setup-remote-server` and then run `wearerequired-setup-remote-server` in project folder.