### PR TITLE
Replace plugin slug used as text domain in `block.json` files.

### DIFF
--- a/packages/generate/CHANGELOG.md
+++ b/packages/generate/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+* Replace plugin slug used as text domain in `block.json` files.
+
 ## [0.2.0] - 2021-11-16
 
 ### Added

--- a/packages/generate/lib/commands/plugin.js
+++ b/packages/generate/lib/commands/plugin.js
@@ -231,6 +231,7 @@ After the first run the token gets stored in your system's keychain and will be 
 				pluginDir + '/plugin.php',
 				pluginDir + '/inc/**/*.php',
 				pluginDir + '/assets/js/src/**/*.js',
+				pluginDir + '/assets/js/src/**/*.json',
 			],
 			from: [
 				/Plugin Name([^:])/g, // Ignore the colon so that in "Plugin Name: Plugin Name" only the second is replaced.


### PR DESCRIPTION
Related: https://github.com/wearerequired/wordpress-plugin-boilerplate/issues/186