### PR TITLE
Added option to create block themes

### DIFF
--- a/packages/generate/README.md
+++ b/packages/generate/README.md
@@ -12,7 +12,7 @@ npx @wearerequired/generate@latest wordpress-plugin
 
 ## wordpress-theme
 
-Command for bootstrapping a new WordPress theme based on the [WordPress Theme Boilerplate](https://github.com/wearerequired/wordpress-theme-boilerplate). It offers a modern build setup and generates PHP, JS, CSS code, and everything else you need to start the theme.
+Command for bootstrapping a new WordPress theme based on the [WordPress Theme Boilerplate](https://github.com/wearerequired/wordpress-theme-boilerplate) or the [WordPress Block Theme Boilerplate](https://github.com/wearerequired/wordpress-block-theme-boilerplate). It offers a modern build setup and generates PHP, JS, CSS code, and everything else you need to start the theme.
 
 ```bash
 npx @wearerequired/generate@latest wordpress-theme

--- a/packages/generate/lib/commands/theme.js
+++ b/packages/generate/lib/commands/theme.js
@@ -64,6 +64,7 @@ After the first run the token gets stored in your system's keychain and will be 
 	let defaultInput = {
 		themeName: 'My Theme',
 		themeDescription: '',
+		isBlockTheme: false,
 		themeSlug: '',
 		githubSlug: '',
 		phpNamespace: '',
@@ -99,6 +100,7 @@ After the first run the token gets stored in your system's keychain and will be 
 		githubToken,
 		themeName,
 		themeDescription,
+		isBlockTheme,
 		themeSlug,
 		phpNamespace,
 		githubSlug,
@@ -124,6 +126,12 @@ After the first run the token gets stored in your system's keychain and will be 
 			name: 'themeDescription',
 			default: defaultInput.themeDescription,
 			message: 'Enter the description of the theme:',
+		},
+		{
+			type: 'confirm',
+			name: 'isBlockTheme',
+			default: defaultInput.isBlockTheme,
+			message: 'Should this be a block theme?',
 		},
 		{
 			type: 'input',
@@ -167,6 +175,7 @@ After the first run the token gets stored in your system's keychain and will be 
 	config.set( 'themeLastInput', {
 		themeName,
 		themeDescription,
+		isBlockTheme,
 		themeSlug,
 		phpNamespace,
 		githubSlug,
@@ -213,7 +222,8 @@ After the first run the token gets stored in your system's keychain and will be 
 	// Create the repository.
 	let githubRepo;
 	await runStep( 'Creating repository using template', 'Could not create repo.', async () => {
-		const [ templateOwner, templateName ] = config.get( 'themeTemplateRepo' ).split( '/' );
+
+		const [ templateOwner, templateName ] = config.get( isBlockTheme ? 'blockThemeTemplateRepo' : 'themeTemplateRepo' ).split( '/' );
 		githubRepo = await github.createRepositoryUsingTemplate( {
 			templateOwner,
 			templateName,

--- a/packages/generate/lib/config.js
+++ b/packages/generate/lib/config.js
@@ -10,6 +10,11 @@ const schema = {
 		pattern: '^[a-zA-Z0-9-]+/[a-zA-Z0-9.-]+$',
 		default: 'wearerequired/wordpress-plugin-boilerplate',
 	},
+	blockThemeTemplateRepo: {
+		type: 'string',
+		pattern: '^[a-zA-Z0-9-]+/[a-zA-Z0-9.-]+$',
+		default: 'wearerequired/wordpress-block-theme-boilerplate',
+	},
 	themeTemplateRepo: {
 		type: 'string',
 		pattern: '^[a-zA-Z0-9-]+/[a-zA-Z0-9.-]+$',


### PR DESCRIPTION
Enhanced the `npx @wearerequired/generate@latest wordpress-theme` command.

You can now select if you would like to create a theme based on the block theme boilerplate repo.

- [x] [Block Theme Boilerplate](https://github.com/wearerequired/wordpress-block-theme-boilerplate) repo needs to be updated and should use placeholders.